### PR TITLE
fix: Change download url due to certificate and path errors

### DIFF
--- a/src/downloadChromeExtension.ts
+++ b/src/downloadChromeExtension.ts
@@ -21,7 +21,7 @@ const downloadChromeExtension = (
       if (fs.existsSync(extensionFolder)) {
         rimraf.sync(extensionFolder);
       }
-      const fileURL = `https://www.xupea.com/crx/${chromeStoreID}.crx`; // eslint-disable-line
+      const fileURL = `https://clients2.google.com/service/update2/crx?response=redirect&acceptformat=crx2,crx3&x=id%3D${chromeStoreID}%26uc&prodversion=${process.versions.chrome}`; // eslint-disable-line
       const filePath = path.resolve(`${extensionFolder}.crx`);
       downloadFile(fileURL, filePath)
         .then(() => {


### PR DESCRIPTION
The LetsEncrypt certificate expired on 29/09/2024 and the URLs e.g. https://www.xupea.com/crx/fmkadmapgofadopljbjfkapdkoienihi.crx throw a 404.

Going back to the original URL fixes the problem.

To reproduce this you need to go to the extensions folder and delete the current version to force a download.